### PR TITLE
Remove abstain votes from quorum calculation

### DIFF
--- a/src/OptimismGovernor.sol
+++ b/src/OptimismGovernor.sol
@@ -759,7 +759,6 @@ contract OptimismGovernor is
      * @dev See {IGovernor-COUNTING_MODE}.
      * Params encoding:
      * - modules = custom external params depending on module used
-     * - abstain = abstain votes
      */
     function COUNTING_MODE()
         public

--- a/src/OptimismGovernor.sol
+++ b/src/OptimismGovernor.sol
@@ -759,6 +759,7 @@ contract OptimismGovernor is
      * @dev See {IGovernor-COUNTING_MODE}.
      * Params encoding:
      * - modules = custom external params depending on module used
+     * - abstain = abstain votes
      */
     function COUNTING_MODE()
         public
@@ -767,7 +768,7 @@ contract OptimismGovernor is
         override(GovernorCountingSimpleUpgradeableV2, IGovernorUpgradeable)
         returns (string memory)
     {
-        return "support=bravo&quorum=against,for,abstain&params=modules";
+        return "support=bravo&quorum=against,for&params=modules";
     }
 
     /**
@@ -842,6 +843,7 @@ contract OptimismGovernor is
 
     /**
      * @dev Updated version in which quorum is based on `proposalId` instead of snapshot block.
+     * @dev Removed abstain votes from quorum calculation. -> Feb 18, 2025
      */
     function _quorumReached(uint256 proposalId)
         internal
@@ -850,9 +852,8 @@ contract OptimismGovernor is
         override(GovernorCountingSimpleUpgradeableV2, GovernorUpgradeableV2)
         returns (bool)
     {
-        (uint256 againstVotes, uint256 forVotes, uint256 abstainVotes) = proposalVotes(proposalId);
-
-        return quorum(proposalId) <= againstVotes + forVotes + abstainVotes;
+        (uint256 againstVotes, uint256 forVotes,) = proposalVotes(proposalId);
+        return quorum(proposalId) <= againstVotes + forVotes;
     }
 
     /**

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -2337,7 +2337,7 @@ contract UpgradeToLive is OptimismGovernorTest {
     address proxyAdminOP = 0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0;
 
     function setUp() public override {
-        vm.createSelectFork(vm.rpcUrl("https://mainnet.optimism.io"));
+        vm.createSelectFork(vm.rpcUrl("https://mainnet.optimism.io"), 126844298);
     }
 
     function test_UpgradesToNewImplementationAddress() public {


### PR DESCRIPTION
This is a quick implementation to remove abstain votes from the quorum calculation along with some tests. 

This change was as a result of a deep dive form the OP Foundation, from Josiah from the Foundation:

"This change removes Abstain votes from our Quorum calculation in order to address an edge case where casting Abstain votes has the unintended aside-effect of reducing the number of votes needed to determine the outcome of a proposal in instances where quorum has not yet been met."