### PR TITLE
feat: add proposer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The contracts in this repo are designed to be used by the following roles:
   - Update voting period (number of blocks a proposal can be voted on)
   - Update proposal threshold (number of votes required to create a proposal)
   - Update quorum (number of votes required to pass a proposal, snapshotted at the time of proposal creation)
+  - Transfer authorized proposer role to a new address
+
+- **authorized proposer** is an address that can submit proposals. This will initialy be set to be the same as the manager address however it is planned to change to the address of the ProposalValidator contract. The address has the following permissions:
+  - Create proposals
 
 - **voter** is any address that has OP tokens delegated to it
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The contracts in this repo are designed to be used by the following roles:
   - Update quorum (number of votes required to pass a proposal, snapshotted at the time of proposal creation)
   - Transfer authorized proposer role to a new address
 
-- **authorized proposer** is an address that can submit proposals. This will initialy be set to be the same as the manager address however it is planned to change to the address of the ProposalValidator contract. The address has the following permissions:
+- **authorized proposer** is an address that can submit proposals. This will initially be set to be the same as the manager address however it is planned to change to the address of the ProposalValidator contract. The address has the following permissions:
   - Create proposals
 
 - **voter** is any address that has OP tokens delegated to it

--- a/src/OptimismGovernor.sol
+++ b/src/OptimismGovernor.sol
@@ -123,7 +123,7 @@ contract OptimismGovernor is
 
     /// @notice The address of an authorized proposer
     /// @dev Initially this will be the same address as the manager
-    /// @dev When the ProposalValidator is intoduced the authorized proposer will change to that address.
+    /// @dev When the ProposalValidator is introduced the authorized proposer will change to that address.
     address public authorizedProposer;
 
     /*//////////////////////////////////////////////////////////////

--- a/src/OptimismGovernor.sol
+++ b/src/OptimismGovernor.sol
@@ -68,6 +68,7 @@ contract OptimismGovernor is
     event ProposalDeadlineUpdated(uint256 proposalId, uint64 deadline);
     event TimelockChange(address oldTimelock, address newTimelock);
     event ProposalQueued(uint256 proposalId, uint256 eta);
+    event AuthorizedProposerSet(address indexed oldAuthorizedProposer, address indexed newAuthorizedProposer);
 
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
@@ -83,6 +84,7 @@ contract OptimismGovernor is
     error InvalidVoteType();
     error NotManagerOrTimelock();
     error NotAlligator();
+    error NotValidProposer();
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -119,6 +121,11 @@ contract OptimismGovernor is
     /// @notice Block number to check if proposal is previous or after upgrade
     uint256 internal _upgradeBlock;
 
+    /// @notice The address of an authorized proposer
+    /// @dev Initially this will be the same address as the manager
+    /// @dev When the ProposalValidator is intoduced the authorized proposer will change to that address.
+    address public authorizedProposer;
+
     /*//////////////////////////////////////////////////////////////
                                MODIFIERS
     //////////////////////////////////////////////////////////////*/
@@ -131,6 +138,12 @@ contract OptimismGovernor is
 
     modifier onlyAlligator() {
         if (_msgSender() != alligator) revert NotAlligator();
+        _;
+    }
+
+    modifier onlyValidProposer() {
+        address sender = _msgSender();
+        if (sender != authorizedProposer && sender != manager && sender != timelock()) revert NotValidProposer();
         _;
     }
 
@@ -181,18 +194,21 @@ contract OptimismGovernor is
      * @param _votableSupplyOracle The new address of the votable supply oracle.
      * @param _proposalTypesConfigurator The new address of the proposal types configurator.
      * @param _timelockAddress The address of the timelock.
+     * @param _authorizedProposer The address of the authorized proposer.
      */
     function reinitialize(
         address _alligator,
         address _votableSupplyOracle,
         address _proposalTypesConfigurator,
-        TimelockControllerUpgradeable _timelockAddress
+        TimelockControllerUpgradeable _timelockAddress,
+        address _authorizedProposer
     ) public reinitializer(uint8(VERSION())) {
         alligator = _alligator;
         VOTABLE_SUPPLY_ORACLE = IVotableSupplyOracle(_votableSupplyOracle);
         PROPOSAL_TYPES_CONFIGURATOR = IProposalTypesConfigurator(_proposalTypesConfigurator);
         _upgradeBlock = block.number;
         _timelock = _timelockAddress;
+        authorizedProposer = _authorizedProposer;
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -303,6 +319,15 @@ contract OptimismGovernor is
     }
 
     /**
+     * @notice Set the authorized proposer address. Only the manager or timelock can call this function.
+     * @param _newAuthorizedProposer The new authorized proposer address.
+     */
+    function setAuthorizedProposer(address _newAuthorizedProposer) external onlyManagerOrTimelock {
+        emit AuthorizedProposerSet(authorizedProposer, _newAuthorizedProposer);
+        authorizedProposer = _newAuthorizedProposer;
+    }
+
+    /**
      * @dev Public endpoint to update the underlying timelock instance. Restricted to the timelock itself, so updates
      * must be proposed, scheduled, and executed through governance proposals.
      *
@@ -354,7 +379,7 @@ contract OptimismGovernor is
     }
 
     /**
-     * @notice Propose a new proposal. Only the manager or an address with votes above the proposal threshold can propose.
+     * @notice Propose a new proposal. Only the authorized proposer, manager or an address with votes above the proposal threshold can propose.
      * See {IGovernor-propose}.
      * @dev Updated version of `propose` in which `proposalType` is set and checked.
      */
@@ -364,7 +389,7 @@ contract OptimismGovernor is
         bytes[] memory calldatas,
         string memory description,
         uint8 proposalType
-    ) public virtual onlyManagerOrTimelock returns (uint256 proposalId) {
+    ) public virtual onlyValidProposer returns (uint256 proposalId) {
         // Only manager or timelock can propose, so this check can be skipped (otherwise stack too deep issues)
         // address proposer = _msgSender();
         // if (proposer != manager && getVotes(proposer, block.number - 1) < proposalThreshold()) {
@@ -411,7 +436,7 @@ contract OptimismGovernor is
     }
 
     /**
-     * @notice Propose a new proposal using a custom voting module. Only the manager or an address with votes above the
+     * @notice Propose a new proposal using a custom voting module. Only the authorized proposer, manager or an address with votes above the
      * proposal threshold can propose.
      * @param module The address of the voting module to use for this proposal.
      * @param proposalData The proposal data to pass to the voting module.
@@ -425,9 +450,9 @@ contract OptimismGovernor is
         bytes memory proposalData,
         string memory description,
         uint8 proposalType
-    ) public virtual onlyManagerOrTimelock returns (uint256 proposalId) {
+    ) public virtual onlyValidProposer returns (uint256 proposalId) {
         address proposer = _msgSender();
-        if (proposer != manager) {
+        if (proposer != manager && proposer != authorizedProposer) {
             if (getVotes(proposer, block.number - 1) < proposalThreshold()) revert InvalidVotesBelowThreshold();
         }
 

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -1187,7 +1187,7 @@ contract QueueWithOptimisticModule is OptimismGovernorTest {
         bytes memory proposalData = abi.encode(OptimisticProposalSettings(1200, false));
 
         vm.startPrank(_actor);
-        uint256 proposalId = governor.proposeWithModule(optimisticModule, proposalData, description, 2);
+        governor.proposeWithModule(optimisticModule, proposalData, description, 2);
         vm.roll(deadline + 1);
         vm.expectRevert(OptimisticModule.OptimisticModuleOnlySignal.selector);
         governor.queueWithModule(optimisticModule, proposalData, keccak256(bytes(description)));
@@ -1619,7 +1619,7 @@ contract ExecuteWithOptimisticModule is OptimismGovernorTest {
         bytes memory proposalData = abi.encode(OptimisticProposalSettings(1200, false));
 
         vm.startPrank(manager);
-        uint256 proposalId = governor.proposeWithModule(optimisticModule, proposalData, description, 2);
+        governor.proposeWithModule(optimisticModule, proposalData, description, 2);
         vm.roll(deadline + 1);
         vm.expectRevert();
         governor.executeWithModule(optimisticModule, proposalData, keccak256(bytes(description)));

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -83,6 +83,7 @@ contract OptimismGovernorTest is Test {
     event ProposalExecuted(uint256 proposalId);
     event ProposalTypeUpdated(uint256 indexed proposalId, uint8 proposalType);
     event ManagerSet(address indexed oldManager, address indexed newManager);
+    event AuthorizedProposerSet(address indexed oldAuthorizedProposer, address indexed newAuthorizedProposer);
 
     /*//////////////////////////////////////////////////////////////
                                  ERRORS
@@ -96,6 +97,7 @@ contract OptimismGovernorTest is Test {
     error InvalidVotesBelowThreshold();
     error InvalidProposalExists();
     error NotManagerOrTimelock();
+    error NotValidProposer();
 
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
@@ -106,6 +108,7 @@ contract OptimismGovernorTest is Test {
     VotableSupplyOracle internal votableSupplyOracle;
     Timelock public timelock;
     ExecutionTargetFake public targetFake;
+    address internal authorizedProposer;
     address internal proxyAdmin = makeAddr("proxyAdmin");
     address internal manager = makeAddr("manager");
     address internal minter = makeAddr("minter");
@@ -127,6 +130,9 @@ contract OptimismGovernorTest is Test {
 
     function setUp() public virtual {
         vm.startPrank(deployer);
+
+        // Set the authorized proposer as the manager
+        authorizedProposer = manager;
 
         // Deploy token
         govToken = new TokenMock(minter);
@@ -255,6 +261,12 @@ contract OptimismGovernorTest is Test {
         else return governor.timelock();
     }
 
+    function _validProposer(uint256 _actorSeed) internal view returns (address) {
+        if (_actorSeed % 3 == 1) return manager;
+        else if (_actorSeed % 3 == 2) return governor.timelock();
+        else return authorizedProposer;
+    }
+
     function _createValidProposal() internal returns (uint256) {
         address[] memory targets = new address[](1);
         targets[0] = address(targetFake);
@@ -368,6 +380,33 @@ contract Propose is OptimismGovernorTest {
         assertGt(governor.proposalSnapshot(proposalId), 0);
     }
 
+    function testFuzz_CreatesProposalWhenAuthorizedProposer(address _authorizedProposer, uint256 _proposalThreshold)
+        public
+        virtual
+    {
+        _proposalThreshold = bound(_proposalThreshold, 0, type(uint208).max);
+        // Set the authorized proposer to a random address and the proposal threshold
+        vm.startPrank(manager);
+        governor.setAuthorizedProposer(_authorizedProposer);
+        governor.setProposalThreshold(_proposalThreshold);
+        vm.stopPrank();
+
+        // Set dummy proposal data
+        address[] memory targets = new address[](1);
+        targets[0] = address(this);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSelector(this.executeCallback.selector);
+
+        // Propose as the authorized proposer
+        uint256 proposalId;
+        vm.prank(_authorizedProposer);
+        proposalId = governor.propose(targets, values, calldatas, "Test", 0);
+
+        // Assert the proposal was created
+        assertGt(governor.proposalSnapshot(proposalId), 0);
+    }
+
     function testRevert_WithType_InvalidProposalType() public virtual {
         address[] memory targets = new address[](1);
         targets[0] = address(this);
@@ -394,6 +433,30 @@ contract Propose is OptimismGovernorTest {
         vm.expectRevert(InvalidProposalExists.selector);
         governor.propose(targets, values, calldatas, "Test", 0);
         vm.stopPrank();
+    }
+
+    function testFuzz_RevertIf_NotValidProposer(address _caller, address _authorizedProposer) public virtual {
+        // Assume the actor is not the authorized proposer, manager, timelock or proxy admin
+        vm.assume(
+            _caller != _authorizedProposer && _caller != manager && _caller != governor.timelock()
+                && _caller != proxyAdmin
+        );
+
+        // Set the authorized proposer to a random address
+        vm.prank(manager);
+        governor.setAuthorizedProposer(_authorizedProposer);
+
+        // Create dummy proposal data
+        address[] memory targets = new address[](1);
+        targets[0] = address(this);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeWithSelector(this.executeCallback.selector);
+
+        // Call propose
+        vm.expectRevert(NotValidProposer.selector);
+        vm.prank(_caller);
+        governor.propose(targets, values, calldatas, "Test");
     }
 }
 
@@ -471,6 +534,45 @@ contract ProposeWithModule is OptimismGovernorTest {
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernorUpgradeable.ProposalState.Pending));
     }
 
+    function testFuzz_CreatesProposalWhenAuthorizedProposer(address _authorizedProposer, uint256 _proposalThreshold)
+        public
+        virtual
+    {
+        _proposalThreshold = bound(_proposalThreshold, 0, type(uint208).max);
+        vm.startPrank(manager);
+        // Set the authorized proposer to a random address and the proposal threshold
+        governor.setAuthorizedProposer(_authorizedProposer);
+        governor.setProposalThreshold(_proposalThreshold);
+
+        uint8 _proposalType = 1;
+        uint256 snapshot = block.number + governor.votingDelay();
+        uint256 deadline = snapshot + governor.votingPeriod();
+        bytes memory proposalData = _formatProposalData(0);
+        // Calculate the proposal id
+        uint256 proposalId =
+            governor.hashProposalWithModule(address(module), proposalData, keccak256(bytes(description)));
+        vm.stopPrank();
+        vm.expectEmit();
+        emit ProposalCreated(
+            proposalId,
+            _authorizedProposer,
+            address(module),
+            proposalData,
+            snapshot,
+            deadline,
+            description,
+            _proposalType
+        );
+        // Propose as the authorized proposer
+        vm.prank(_authorizedProposer);
+        governor.proposeWithModule(VotingModule(module), proposalData, description, _proposalType);
+
+        assertEq(governor.proposals(proposalId).proposalType, _proposalType);
+        assertEq(governor.proposalSnapshot(proposalId), snapshot);
+        assertEq(governor.proposalDeadline(proposalId), deadline);
+        assertEq(uint8(governor.state(proposalId)), uint8(IGovernorUpgradeable.ProposalState.Pending));
+    }
+
     function test_RevertIf_InvalidProposalType() public virtual {
         bytes memory proposalData = _formatProposalData(0);
         uint8 invalidPropType = 3;
@@ -515,6 +617,25 @@ contract ProposeWithModule is OptimismGovernorTest {
         vm.prank(manager);
         vm.expectRevert("Governor: module not approved");
         governor.proposeWithModule(VotingModule(module_), proposalData, description, 0);
+    }
+
+    function testFuzz_RevertIf_NotValidProposer(address _caller, address _authorizedProposer) public virtual {
+        // Assume the actor is not the authorized proposer, manager, timelock or proxy admin
+        vm.assume(
+            _caller != _authorizedProposer && _caller != manager && _caller != governor.timelock()
+                && _caller != proxyAdmin
+        );
+
+        // Set the authorized proposer to a random address
+        vm.prank(manager);
+        governor.setAuthorizedProposer(_authorizedProposer);
+
+        bytes memory proposalData = _formatProposalData(0);
+        address module = makeAddr("module");
+
+        vm.prank(_caller);
+        vm.expectRevert(NotValidProposer.selector);
+        governor.proposeWithModule(VotingModule(module), proposalData, description, 0);
     }
 }
 
@@ -2275,6 +2396,23 @@ contract SetManager is OptimismGovernorTest {
         vm.prank(_actor);
         vm.expectRevert(NotManagerOrTimelock.selector);
         governor.setManager(_newManager);
+    }
+}
+
+contract SetAuthorizedProposer is OptimismGovernorTest {
+    function testFuzz_SetsNewAuthorizedProposer(address _newAuthorizedProposer, uint256 _actorSeed) public {
+        vm.prank(_managerOrTimelock(_actorSeed));
+        vm.expectEmit();
+        emit AuthorizedProposerSet(address(0), _newAuthorizedProposer);
+        governor.setAuthorizedProposer(_newAuthorizedProposer);
+        assertEq(governor.authorizedProposer(), _newAuthorizedProposer);
+    }
+
+    function testFuzz_RevertIf_NotManager(address _actor, address _newAuthorizedProposer) public {
+        vm.assume(_actor != manager && _actor != governor.timelock() && _actor != proxyAdmin);
+        vm.prank(_actor);
+        vm.expectRevert(NotManagerOrTimelock.selector);
+        governor.setAuthorizedProposer(_newAuthorizedProposer);
     }
 }
 

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -386,10 +386,11 @@ contract Propose is OptimismGovernorTest {
     {
         _proposalThreshold = bound(_proposalThreshold, 0, type(uint208).max);
         // Set the authorized proposer to a random address and the proposal threshold
-        vm.startPrank(manager);
+        vm.prank(manager);
         governor.setAuthorizedProposer(_authorizedProposer);
+
+        vm.prank(manager);
         governor.setProposalThreshold(_proposalThreshold);
-        vm.stopPrank();
 
         // Set dummy proposal data
         address[] memory targets = new address[](1);
@@ -539,9 +540,10 @@ contract ProposeWithModule is OptimismGovernorTest {
         virtual
     {
         _proposalThreshold = bound(_proposalThreshold, 0, type(uint208).max);
-        vm.startPrank(manager);
         // Set the authorized proposer to a random address and the proposal threshold
+        vm.prank(manager);
         governor.setAuthorizedProposer(_authorizedProposer);
+        vm.prank(manager);
         governor.setProposalThreshold(_proposalThreshold);
 
         uint8 _proposalType = 1;
@@ -551,7 +553,6 @@ contract ProposeWithModule is OptimismGovernorTest {
         // Calculate the proposal id
         uint256 proposalId =
             governor.hashProposalWithModule(address(module), proposalData, keccak256(bytes(description)));
-        vm.stopPrank();
         vm.expectEmit();
         emit ProposalCreated(
             proposalId,
@@ -2439,7 +2440,7 @@ contract UpgradeToLive is OptimismGovernorTest {
     address proxyAdminOP = 0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0;
 
     function setUp() public override {
-        vm.createSelectFork(vm.rpcUrl("https://mainnet.optimism.io"));
+        vm.createSelectFork(vm.rpcUrl("https://mainnet.optimism.io"), 126844298);
     }
 
     function test_UpgradesToNewImplementationAddress() public {
@@ -2465,6 +2466,7 @@ contract UpgradeToLive is OptimismGovernorTest {
         Timelock timelock = new Timelock();
         timelock.initialize(14, address(governorProxyOP), address(0));
 
+        address _manager = governorProxyOP.manager();
         vm.startPrank(proxyAdminOP);
         TransparentUpgradeableProxy(payable(address(governorProxyOP))).upgradeToAndCall(
             _newImplementation,
@@ -2473,11 +2475,13 @@ contract UpgradeToLive is OptimismGovernorTest {
                 0x7f08F3095530B67CdF8466B7a923607944136Df0,
                 0x1b7CA7437748375302bAA8954A2447fC3FBE44CC,
                 _newProposalTypesConfigurator,
-                TimelockControllerUpgradeable(payable(address(timelock)))
+                TimelockControllerUpgradeable(payable(address(timelock))),
+                _manager
             )
         );
         assertEq(TransparentUpgradeableProxy(payable(address(governorProxyOP))).implementation(), _newImplementation);
         vm.stopPrank();
+        assertEq(governorProxyOP.authorizedProposer(), governorProxyOP.manager());
         assertEq(governorProxyOP.VERSION(), 4);
         assertEq(address(governorProxyOP.alligator()), 0x7f08F3095530B67CdF8466B7a923607944136Df0);
         assertEq(address(governorProxyOP.VOTABLE_SUPPLY_ORACLE()), 0x1b7CA7437748375302bAA8954A2447fC3FBE44CC);
@@ -2531,6 +2535,7 @@ contract UpgradeToLive is OptimismGovernorTest {
         Timelock timelock = new Timelock();
         timelock.initialize(14, address(governorProxyOP), address(0));
 
+        address _manager = governorProxyOP.manager();
         vm.prank(proxyAdminOP);
         TransparentUpgradeableProxy(payable(address(governorProxyOP))).upgradeToAndCall(
             _newImplementation,
@@ -2539,10 +2544,12 @@ contract UpgradeToLive is OptimismGovernorTest {
                 0x7f08F3095530B67CdF8466B7a923607944136Df0,
                 0x1b7CA7437748375302bAA8954A2447fC3FBE44CC,
                 _newProposalTypesConfigurator,
-                TimelockControllerUpgradeable(payable(address(timelock)))
+                TimelockControllerUpgradeable(payable(address(timelock))),
+                _manager
             )
         );
 
+        assertEq(governorProxyOP.authorizedProposer(), governorProxyOP.manager());
         assertEq(governorProxyOP.VERSION(), 4);
         address managerOfGovernor = governorProxyOP.manager();
         address[] memory targets = new address[](1);

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -380,7 +380,7 @@ contract Propose is OptimismGovernorTest {
         assertGt(governor.proposalSnapshot(proposalId), 0);
     }
 
-    function testFuzz_CreatesProposalWhenAuthorizedProposer(address _authorizedProposer, uint256 _proposalThreshold)
+    function testFuzz_CreatesProposalAsAuthorizedProposer(address _authorizedProposer, uint256 _proposalThreshold)
         public
         virtual
     {
@@ -535,7 +535,7 @@ contract ProposeWithModule is OptimismGovernorTest {
         assertEq(uint8(governor.state(proposalId)), uint8(IGovernorUpgradeable.ProposalState.Pending));
     }
 
-    function testFuzz_CreatesProposalWhenAuthorizedProposer(address _authorizedProposer, uint256 _proposalThreshold)
+    function testFuzz_CreatesProposalAsAuthorizedProposer(address _authorizedProposer, uint256 _proposalThreshold)
         public
         virtual
     {


### PR DESCRIPTION
Adds support for a new `authorizedProposer` role. This role will be able to create proposals along with the manager and timelock. Initially will be set to the same address as the `manager`, however eventually it will change using the `setAuthorizedProposer` to the new `ProposalValidator` contract when it is ready.