### PR TITLE
L-02 Incorrect Documentation &  L-03 Incomplete Documentation

### DIFF
--- a/src/OptimismGovernor.sol
+++ b/src/OptimismGovernor.sol
@@ -379,7 +379,7 @@ contract OptimismGovernor is
     }
 
     /**
-     * @notice Propose a new proposal. Only the authorized proposer, manager or an address with votes above the proposal threshold can propose.
+     * @notice Propose a new proposal. Only the authorized proposer, manager, and timelock can propose ignoring the proposal threshold.
      * See {IGovernor-propose}.
      * @dev Updated version of `propose` in which `proposalType` is set and checked.
      */
@@ -390,7 +390,7 @@ contract OptimismGovernor is
         string memory description,
         uint8 proposalType
     ) public virtual onlyValidProposer returns (uint256 proposalId) {
-        // Only manager or timelock can propose, so this check can be skipped (otherwise stack too deep issues)
+        // Only authorized proposer, manager, or timelock can propose, so this check can be skipped (otherwise stack too deep issues)
         // address proposer = _msgSender();
         // if (proposer != manager && getVotes(proposer, block.number - 1) < proposalThreshold()) {
         //     revert InvalidVotesBelowThreshold();
@@ -436,8 +436,7 @@ contract OptimismGovernor is
     }
 
     /**
-     * @notice Propose a new proposal using a custom voting module. Only the authorized proposer, manager or an address with votes above the
-     * proposal threshold can propose.
+     * @notice Propose a new proposal using a custom voting module. Only the authorized proposer, manager, and timelock can propose ignoring the proposal threshold.
      * @param module The address of the voting module to use for this proposal.
      * @param proposalData The proposal data to pass to the voting module.
      * @param description The description of the proposal.
@@ -452,9 +451,11 @@ contract OptimismGovernor is
         uint8 proposalType
     ) public virtual onlyValidProposer returns (uint256 proposalId) {
         address proposer = _msgSender();
-        if (proposer != manager && proposer != authorizedProposer) {
-            if (getVotes(proposer, block.number - 1) < proposalThreshold()) revert InvalidVotesBelowThreshold();
-        }
+
+        // Only authorized proposer, manager, or timelock can propose, so this check can be skipped (otherwise stack too deep issues)
+        // if (proposer != manager && proposer != authorizedProposer) {
+        // if (getVotes(proposer, block.number - 1) < proposalThreshold()) revert InvalidVotesBelowThreshold();
+        // }
 
         require(approvedModules[address(module)], "Governor: module not approved");
 

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -384,6 +384,7 @@ contract Propose is OptimismGovernorTest {
         public
         virtual
     {
+        vm.assume(_authorizedProposer != proxyAdmin);
         _proposalThreshold = bound(_proposalThreshold, 0, type(uint208).max);
         // Set the authorized proposer to a random address and the proposal threshold
         vm.prank(manager);
@@ -539,6 +540,7 @@ contract ProposeWithModule is OptimismGovernorTest {
         public
         virtual
     {
+        vm.assume(_authorizedProposer != proxyAdmin);
         _proposalThreshold = bound(_proposalThreshold, 0, type(uint208).max);
         // Set the authorized proposer to a random address and the proposal threshold
         vm.prank(manager);


### PR DESCRIPTION
Took this opportunity to fix a flaking test when the fuzzer impersonates the proxy admin address and causes a failure on the TransparentUpgradeableProxy for the governor. 