### PR TITLE
L-06 Bump Governor Version

### DIFF
--- a/src/OptimismGovernor.sol
+++ b/src/OptimismGovernor.sol
@@ -799,7 +799,7 @@ contract OptimismGovernor is
      * @dev Returns the current version of the governor.
      */
     function VERSION() public pure virtual returns (uint256) {
-        return 4;
+        return 5;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/OptimismGovernor.t.sol
+++ b/test/OptimismGovernor.t.sol
@@ -2482,7 +2482,7 @@ contract UpgradeToLive is OptimismGovernorTest {
         assertEq(TransparentUpgradeableProxy(payable(address(governorProxyOP))).implementation(), _newImplementation);
         vm.stopPrank();
         assertEq(governorProxyOP.authorizedProposer(), governorProxyOP.manager());
-        assertEq(governorProxyOP.VERSION(), 4);
+        assertEq(governorProxyOP.VERSION(), 5);
         assertEq(address(governorProxyOP.alligator()), 0x7f08F3095530B67CdF8466B7a923607944136Df0);
         assertEq(address(governorProxyOP.VOTABLE_SUPPLY_ORACLE()), 0x1b7CA7437748375302bAA8954A2447fC3FBE44CC);
         assertEq(address(governorProxyOP.PROPOSAL_TYPES_CONFIGURATOR()), address(_newProposalTypesConfigurator));
@@ -2550,7 +2550,7 @@ contract UpgradeToLive is OptimismGovernorTest {
         );
 
         assertEq(governorProxyOP.authorizedProposer(), governorProxyOP.manager());
-        assertEq(governorProxyOP.VERSION(), 4);
+        assertEq(governorProxyOP.VERSION(), 5);
         address managerOfGovernor = governorProxyOP.manager();
         address[] memory targets = new address[](1);
         targets[0] = address(targetFake);


### PR DESCRIPTION
Per OZ's audit find L-06, this PR bumps the version of the Governor contract.

> The OptimismGovernor contract was modified to include new logic for the authorized proposer. However, the VERSION was not incremented. As a result, the reinitialize function is not callable and will revert due to the reinitializer modifier. While it is possible to set the authorizedProposer using the setAuthorizedProposer function, this approach bypasses the standard practice of handling state changes during upgrades. Consider increasing the VERSION of the contract and setting the parameters through the reinitialize logic.